### PR TITLE
[Vulnerability] - createSecureDocBuilderFactory was added to JaxpDOMP…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.5.0</version>
+      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/eigenbase/xom/wrappers/JaxpDOMParser.java
+++ b/src/main/java/org/eigenbase/xom/wrappers/JaxpDOMParser.java
@@ -22,6 +22,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
@@ -45,7 +46,7 @@ public class JaxpDOMParser extends GenericDOMParser {
     /** Creates a parser. */
     public JaxpDOMParser(boolean validating) throws XOMException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = createSecureDocBuilderFactory();
             factory.setValidating(validating);
             try {
                 factory.setAttribute(VALIDATION_FEATURE, new Boolean(validating));
@@ -79,6 +80,23 @@ public class JaxpDOMParser extends GenericDOMParser {
             handleErrors();
             throw new XOMException(e, "Document parse failed");
         }
+    }
+
+    /**
+     * Creates an instance of {@link DocumentBuilderFactory} class
+     * with enabled {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
+     * Enabling this feature prevents from some XXE attacks (e.g. XML bomb)
+     * See http://jira.pentaho.com/browse/PPP-3506 for more details.
+     *
+     * @throws ParserConfigurationException if feature can't be enabled
+     *
+     */
+    private DocumentBuilderFactory createSecureDocBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+        docBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+        return docBuilderFactory;
     }
 }
 


### PR DESCRIPTION
@julianhyde, could you please take a look?

Vulnerability of eigenbase-xom was detected in scope of work on http://jira.pentaho.com/browse/PPP-3506. 
Additionally xercesImpl was updated since org.apache.xerces.jaxp.DocumentBuilderFactoryImpl of 2.5.0 do not implement setFeature method.

Thanks.